### PR TITLE
Convert Sideqkiq ENV vars to `Rails.application.secrets`

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,7 @@ require 'sidekiq'
 require 'sidekiq/web'
 
 Sidekiq::Web.use(Rack::Auth::Basic) do |user, password|
-  [user, password] == [ENV['SECRET_KEY_ACCESS'], ENV['SECRET_KEY_PASSWORD']]
+  [user, password] == [Rails.application.secrets.secret_key_access, Rails.application.secrets.secret_key_password.to_s]
 end
 
 Sidekiq.configure_server do |config|


### PR DESCRIPTION
The `sideqkiq.rb` initializer was using the `SECRET_KEY_ACCESS` and
`SECRET_KEY_PASSWORD` loaded from ENV vars.

On Rails 4, there is a feature called `Rails secrets` to handle
this types of credentials.

More info:
`https://stuff-things.net/2017/01/04/secret-rails-configurations/`

Closes #15 