### PR TITLE
Remove docker automated label from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![ruby](https://img.shields.io/badge/Ruby-2.4.2-green.svg)
 ![rails](https://img.shields.io/badge/Rails-5.0.1-green.svg)
-![rails](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg)
 [![Build Status](https://travis-ci.org/freesendmails/free-send-mails-api.svg?branch=master)](https://travis-ci.org/freesendmails/free-send-mails-api)
 
 `free send mails` This project is focused on making an email server available to static sites. In a simple and low code.


### PR DESCRIPTION
The existing label was using the wrong repository handle (`jrottenberg/ffmpeg` instead of `freesendmails/free-send-mails-api`).

Since this repository is not in sync with a public repository on the docker hub, this label is actually not necessary.