### PR TITLE
Add tests to docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM ruby:2.3-slim
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       build-essential nodejs
 
-ENV INSTALL_PATH /usr/src/app
+ENV APP_FOLDER /usr/src/app
 
-ADD . $INSTALL_PATH
-WORKDIR $INSTALL_PATH
+ADD . $APP_FOLDER
+WORKDIR $APP_FOLDER
 
 RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV MAILGUN_SMTP_PORT replaceme
 ENV MAILGUN_DOMAIN replaceme
 ENV MAILGUN_SMTP_LOGIN replaceme
 ENV MAILGUN_SMTP_PASSWORD replaceme
-ENV RAILS_LOG_TO_STDOUT true
 ENV SECRET_KEY_BASE replaceme
 RUN echo 'gem: --no-document' > /etc/gemrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ FROM ruby:2.3-slim
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       build-essential nodejs
 
-RUN echo 'gem: --no-document' > /etc/gemrc
-
 ENV INSTALL_PATH /usr/src/app
-RUN mkdir -p $INSTALL_PATH
 
 ADD . $INSTALL_PATH
 WORKDIR $INSTALL_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM ruby:2.3-slim
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       build-essential nodejs
 
-ENV RAILS_ENV production
 ENV MAILGUN_SMTP_SERVER replaceme
 ENV MAILGUN_SMTP_PORT replaceme
 ENV MAILGUN_DOMAIN replaceme

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.3-slim
 
-RUN apt-get update && apt-get install -qq -y --no-install-recommends \
-      build-essential nodejs
+RUN apt-get update && apt-get install -y build-essential nodejs
 
 ENV APP_FOLDER /usr/src/app
 ENV BUNDLE_JOBS=4

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       build-essential nodejs
 
 ENV APP_FOLDER /usr/src/app
+ENV BUNDLE_JOBS=4
 
 ADD . $APP_FOLDER
 WORKDIR $APP_FOLDER

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,3 @@ COPY Gemfile $INSTALL_PATH/Gemfile
 COPY Gemfile.lock $INSTALL_PATH/Gemfile.lock
 RUN bundle install --without development test
 COPY . .
-CMD puma -C config/puma.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,6 @@ FROM ruby:2.3-slim
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       build-essential nodejs
 
-ENV MAILGUN_SMTP_SERVER replaceme
-ENV MAILGUN_SMTP_PORT replaceme
-ENV MAILGUN_DOMAIN replaceme
-ENV MAILGUN_SMTP_LOGIN replaceme
-ENV MAILGUN_SMTP_PASSWORD replaceme
-ENV SECRET_KEY_BASE replaceme
 RUN echo 'gem: --no-document' > /etc/gemrc
 
 ENV INSTALL_PATH /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN echo 'gem: --no-document' > /etc/gemrc
 
 ENV INSTALL_PATH /usr/src/app
 RUN mkdir -p $INSTALL_PATH
+
+ADD . $INSTALL_PATH
 WORKDIR $INSTALL_PATH
-COPY Gemfile $INSTALL_PATH/Gemfile
-COPY Gemfile.lock $INSTALL_PATH/Gemfile.lock
+
 RUN bundle install
-COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ RUN mkdir -p $INSTALL_PATH
 WORKDIR $INSTALL_PATH
 COPY Gemfile $INSTALL_PATH/Gemfile
 COPY Gemfile.lock $INSTALL_PATH/Gemfile.lock
-RUN bundle install --without development test
+RUN bundle install
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - '3000:3000'
     volumes:
       - '.:/usr/src/app'
+    command: puma -C config/puma.rb
 
   redis:
     image: 'redis:3.2-alpine'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,11 @@ services:
       - RAILS_LOG_TO_STDOUT=true
     command: puma -C config/puma.rb
     depends_on:
-      - 'redis'
+      - redis
     ports:
-      - '3000:3000'
+      - 3000:3000
     volumes:
-      - '.:/usr/src/app'
+      - .:/usr/src/app
 
   tests:
     build: .
@@ -21,15 +21,15 @@ services:
       - RAILS_ENV=test
     command: bundle exec rspec
     volumes:
-      - '.:/usr/src/app'
+      - .:/usr/src/app
 
   redis:
-    image: 'redis:3.2-alpine'
+    image: redis:3.2-alpine
     command: redis-server
     ports:
-      - '6379:6379'
+      - 6379:6379
     volumes:
-      - 'redis:/var/lib/redis/data'
+      - redis:/var/lib/redis/data
 
 volumes:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,20 @@ version: '2'
 services:
 
   website:
+    build: .
+    command: puma -C config/puma.rb
     depends_on:
       - 'redis'
-    build: .
     ports:
       - '3000:3000'
     volumes:
       - '.:/usr/src/app'
-    command: puma -C config/puma.rb
+
+  tests:
+    build: .
+    command: bundle exec rspec
+    volumes:
+      - '.:/usr/src/app'
 
   redis:
     image: 'redis:3.2-alpine'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build: .
     environment:
       - RAILS_ENV=development
+      - RAILS_LOG_TO_STDOUT=true
     command: puma -C config/puma.rb
     depends_on:
       - 'redis'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
 
   website:
     build: .
+    environment:
+      - RAILS_ENV=development
     command: puma -C config/puma.rb
     depends_on:
       - 'redis'
@@ -14,6 +16,8 @@ services:
 
   tests:
     build: .
+    environment:
+      - RAILS_ENV=test
     command: bundle exec rspec
     volumes:
       - '.:/usr/src/app'


### PR DESCRIPTION
In this PR, we're adding the `tests` service to the project's `docker-compose` in order to make it possible to run the tests inside a docker container.

Also, we performed some cleanup around the `Dockerfile` and `docker-compose.yml` files in order to make things a bit more flexible.

Thanks for the help on this one, @diogopms 🙏 💯 