### PR TITLE
Fix: factory_girl deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,9 @@ gem 'base58'
 
 group :development, :test do
   gem 'byebug'
-  gem 'rspec-rails'
-  gem 'factory_girl'
+  gem 'factory_bot'
   gem 'ffaker'
+  gem 'rspec-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     crass (1.0.2)
     diff-lcs (1.3)
     erubis (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
     ffaker (2.7.0)
     ffi (1.9.18)
@@ -161,7 +161,7 @@ PLATFORMS
 DEPENDENCIES
   base58
   byebug
-  factory_girl
+  factory_bot
   ffaker
   firebase
   listen (~> 3.0.5)


### PR DESCRIPTION
# Description (hacktoberfest)

This removes:
```
DEPRECATION WARNING: The factory_girl gem is deprecated. Please upgrade to factory_bot. See https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md for further instructions. (called from ...)
``` 